### PR TITLE
Fix Bookworm compatibility issues, especially around sound.

### DIFF
--- a/asound.conf
+++ b/asound.conf
@@ -1,0 +1,4 @@
+# Dummy asound.conf file to prevent installation errors.
+# This file is created to ensure compatibility with legacy install scripts.
+# The MATRIX Creator sound configuration is handled by other means,
+# such as the /etc/modules-load.d/matrix-mics.conf file.

--- a/boot_modifications.txt
+++ b/boot_modifications.txt
@@ -2,3 +2,4 @@ dtparam=spi=on
 start_x=1
 enable_uart=1
 dtoverlay=spi0-cs,cs1_pin=12
+dtoverlay=gpio-legacy

--- a/matrix-init.bash
+++ b/matrix-init.bash
@@ -25,9 +25,9 @@ case "${MATRIX_DEVICE}" in
     voice_esp32_reset
     read_voice_config
     if [ "${ESP32_RESET}" == "FALSE" ]; then
-      echo 1 > /sys/class/gpio/gpio25/value
+      gpioset gpiochip0 25=1
     else 
-      echo 0 > /sys/class/gpio/gpio25/value
+      gpioset gpiochip0 25=0
     fi
     ;;
 esac


### PR DESCRIPTION
This change addresses compatibility issues with Debian Bookworm, focusing on GPIO access and sound-related components.

The following changes were made:
- Updated scripts to use `gpioset` from `libgpiod-utils` for GPIO control, replacing the deprecated `sysfs` interface.
- Added the `dtoverlay=gpio-legacy` to the boot configuration to ensure that `xc3sprog` and `openocd` continue to function correctly, as they still depend on the `sysfs` interface.
- Created a dummy `asound.conf` file to prevent potential errors from legacy installation scripts.